### PR TITLE
Fixes sitemap generation issue

### DIFF
--- a/process/controllers/main.cfc
+++ b/process/controllers/main.cfc
@@ -44,10 +44,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 		<cfset sitemapsObject.save() />
 
 		<cfif sitemapsObject.getValue('location') eq "web">
-			<cfset filename = "#expandPath(application.configBean.getContext())#/sitemap.xml" />
+			<cfset filename = "#expandPath(application.configBean.getContext() & '/')#sitemap.xml" />
 			<cfset fileURL	= "http://#siteConfig.getDomain()##rc.$.globalConfig().getContext()#/sitemap.xml" />
 		<cfelse>
-			<cfset filename ="#expandPath(application.configBean.getContext())#/#site#/sitemap.xml" />
+			<cfset filename ="#expandPath(application.configBean.getContext() & '/')##site#/sitemap.xml" />
 			<cfset fileURL	= "http://#siteConfig.getDomain()##rc.$.globalConfig().getContext()#/#site#/sitemap.xml" />
 		</cfif>
 		<cftry>


### PR DESCRIPTION
On certain environments especially when using railo expandPath("") will actually return the current url stub instead of the web root.  In order to reliably get the mura web root as a base in my experience it needs to be expandPath("/") which is what this change does.
