### PR TITLE
Change case of tclassextend.subtype value in SQL

### DIFF
--- a/com/meldsolutions/MeldGoogleSitemaps/application/MeldGoogleSitemapsManager.cfc
+++ b/com/meldsolutions/MeldGoogleSitemaps/application/MeldGoogleSitemapsManager.cfc
@@ -79,7 +79,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 				ON
 					tclassextend.subTypeID = tclassextendsets.subTypeID
 				AND
-					tclassextend.subtype = 'default'
+					tclassextend.subtype = 'Default'
 			AND
 				(
 					tclassextend.type = 'Page'
@@ -112,7 +112,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 				AND
 					tcontent.type = tclassextend.type
 				AND
-					tclassextend.subtype = 'default'
+					tclassextend.subtype = 'Default'
 			JOIN
 				tclassextendsets
 				ON


### PR DESCRIPTION
...from "default" to "Default". Some DBs - e.g. PostgreSQL - do a case-sensitive = match, so would not find any records for "default" (thus generating an empty sitemap).